### PR TITLE
Improved script output and error handling

### DIFF
--- a/claimer.py
+++ b/claimer.py
@@ -340,7 +340,7 @@ def get_tx_details_from_blockchaininfo(txid, addr, hardforkheight):
     return found
     
 def get_consent(consentstring):
-    print "Write '%s' to continue" % consentstring
+    print "\nWrite '%s' to continue" % consentstring
 
     answer = raw_input()
     if answer != consentstring:
@@ -388,8 +388,7 @@ class Client(object):
         txhash_hexfmt = txhash[::-1].encode("hex")
         while True:
             try:
-                #address = (coin.seeds[serverindex], self.coin.port)
-                address = ("192.168.56.101", '8346')
+                address = (coin.seeds[serverindex], self.coin.port)
                 print "Connecting to", address, "...",
                 self.sc = socket.create_connection(address)
                 print "SUCCESS!"
@@ -415,9 +414,6 @@ class Client(object):
                     elif cmd == "ping":
                         client.send("pong", payload)
 
-                        # Advertise OUR txhash to the peer if not already done.
-                        # The purpose is to get the peer to add the transaction to their
-                        # mempool and propagate it to the rest of the network.
                         if not self._transaction_sent:
                             client.send("inv", "\x01" + struct.pack("<I", 1) + txhash)
                         elif not self._transaction_accepted:


### PR DESCRIPTION
Thank you for creating this script. I think it's a HUGE help for the community. As such, I'd like to help improve it further.

I've made the script output a bit more clear wrt the protocol back and forth.  I'm open to feedback on these changes, but I think they improve the usability of the script. 

Some of the changes include:
*  General formatting improvements. I.e. '<--' and '-->' indicating protocol message direction. Use of '\t' to indent output related to a particular message.
* The script prints a truncated list of transactions in the mempool. Useful to see if there is a backlog.
*  I added some more error handling around limiting the number of connection retries on failure, and limiting the number of times the tx is retransmitted when it is not being accepted to the mempool.
*  The script now exists when the transaction is found in a block.
*  Alphabetized the coin switch, although I did not reorder the coin class definitions.

Here is sample output for successful (BTF) transaction send:

```
Connecting to ('c.btf.hjy.cc', 8346) ... SUCCESS!
---> 'version' (93 bytes)
<--- 'version' (110 bytes)
---> 'verack' (0 bytes)
<--- 'verack' (0 bytes)
<--- 'sendheaders' (0 bytes)
---> 'headers' (1 bytes)
<--- 'ping' (8 bytes)
---> 'pong' (8 bytes)
---> 'inv' (37 bytes)
---> 'mempool' (0 bytes)
<--- 'addr' (31 bytes)
        Got peer address: 47.90.38.149:8346
<--- 'feefilter' (8 bytes)
        server requires minimum fee of 1000 satoshis
        our fee is >= minimum fee, so should be OK
<--- 'inv' (2881 bytes)
        transaction: dc83cb2012cf1163923c137517d3075448d95613dede1c2087006040c57e46d7
        transaction: a7061c1f4ee5db76a75a38da621ea3754ee76c86fa47b643b7e9fbe7e14c9492
        transaction: c40c873a060cd9d5be7110cf55db3cc94a1c0b51023f59f83eb17af7210a108e
        transaction: ad556e274a46753c1f519ca5f441cd9dfd29dc38cf0bb58580b3ebf04bf4496c
        transaction: ab925a9b4704f274316e62a3a93fe6275d9aa2c6faa0719e1e9d87fa459dde5a
        transaction: d7ed1390022272040f79f4373cf5813df067e119a74d58148c3adf290216b103
        transaction: f25063020b20fdcfb7f7f33b80aaa51b607c17dd1c95c2458e6435efb4525adc
        transaction: 14ccb2f12b823d2f01e083500824c238d88e23dc0d635f76e0ffbd5b14ab94cf
        transaction: 902619939c726a577285f647bdbbefb25ead4dc1ce71defc0222bd7109ddd33a
        transaction: 4a5a1ca7694d010314a3a0168443fbbdae644ac64a2e696ca0c14107d042800c
        ...
        Not printing additional 70 transactions

        OUR TRANSACTION IS IN THEIR MEMPOOL, TRANSACTION ACCEPTED! YAY!
        Consider leaving this script running until it detects the transaction in a block.
<--- 'ping' (8 bytes)
---> 'pong' (8 bytes)
---> 'inv' (37 bytes)
---> 'mempool' (0 bytes)
<--- 'inv' (3097 bytes)
        transaction: dc83cb2012cf1163923c137517d3075448d95613dede1c2087006040c57e46d7
        transaction: 6c80d607c1c3db4c53b8d5aeca69e9ed7ed5e929b4625fb40ea098d79aeaeab3
        transaction: 9e996e7e50930d5d1f0de1e058301e22676df4b0b167fbb643e592baa14ad5a8
        transaction: a7061c1f4ee5db76a75a38da621ea3754ee76c86fa47b643b7e9fbe7e14c9492
        transaction: c40c873a060cd9d5be7110cf55db3cc94a1c0b51023f59f83eb17af7210a108e
        transaction: ad556e274a46753c1f519ca5f441cd9dfd29dc38cf0bb58580b3ebf04bf4496c
        transaction: ef759622e0bdf3a75bf9d0bed7453161e1ac9e5c9b04e38b636ae60e3329c367
        transaction: ab925a9b4704f274316e62a3a93fe6275d9aa2c6faa0719e1e9d87fa459dde5a
        transaction: d7ed1390022272040f79f4373cf5813df067e119a74d58148c3adf290216b103
        transaction: f25063020b20fdcfb7f7f33b80aaa51b607c17dd1c95c2458e6435efb4525adc
        ...
        Not printing additional 76 transactions
        Transaction still in mempool. Continue waiting for block inclusion.
<--- 'ping' (8 bytes)
---> 'pong' (8 bytes)
---> 'inv' (37 bytes)
---> 'mempool' (0 bytes)
<--- 'inv' (37 bytes)
        block: 0000008d1b4871cc1e5c5748c4f435a0c001242bd432c622db8b9f0d2639c471
---> 'getdata' (37 bytes)
        requesting 1 blocks
<--- 'block' (46176 bytes)
        BLOCK WITH OUR TRANSACTION OBSERVED! YES!
        Your coins have been successfully sent. Exiting...
```