### PR TITLE
Add parameters suitable for scripting usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ blockchain.info mode:
 
     claimer.py <cointype> <source transaction ID> <source private key> <source address> <destination address>
     claimer.py BTG 4adc427d330497992710feaa32f85c389ef5106f74e7006878bd14b54500dfff 5K2YUVmWfxbmvsNxCsfvArXdGXm7d5DC9pn4yD75k2UaSYgkXTh 1HKqKTMpBTZZ8H5zcqYEWYBaaWELrDEXeE 1aa5cmqmvQq8YQTEqcTmW7dfBNuFwgdCD
-    
+
 Standalone mode:
 
     claimer.py <cointype> <source transaction ID> <source private key> <source address> <destination address> --txindex <output index in transaction> --satoshis <number of satoshis on the source transaction output>
@@ -54,7 +54,7 @@ Default fee is set to 1000 satoshis, but can be changed with the `--fee` option.
 You can specify multiple destination addresses in the destination address field, the format is:
 
     <address>[,<address>][,<address>][,<address>]...
-    
+
 where `<address>` is either a plain address or an address plus an amount in satoshis, separated by a colon. Examples:
 
     13PuTPQjuZ5Vh1RCrTLqYK79scG2T45LGB
@@ -62,7 +62,7 @@ where `<address>` is either a plain address or an address plus an amount in sato
     13PuTPQjuZ5Vh1RCrTLqYK79scG2T45LGB:1000000,1HKqKTMpBTZZ8H5zcqYEWYBaaWELrDEXeE
     13PuTPQjuZ5Vh1RCrTLqYK79scG2T45LGB:1000000,1HKqKTMpBTZZ8H5zcqYEWYBaaWELrDEXeE:1000000
     13PuTPQjuZ5Vh1RCrTLqYK79scG2T45LGB,1HKqKTMpBTZZ8H5zcqYEWYBaaWELrDEXeE:1000000
-    
+
 One of the destination addresses can be without a specified amount, which makes all the remaining coins (minus the fee) go to that address.
 
 Full example:
@@ -71,16 +71,22 @@ Full example:
 
 USAGE OF THIS SCRIPT IS RISKY AND IF YOU MISTYPE ANYTHING YOU CAN LOSE ALL YOUR COINS
 
+Advanced parameters for usage with scripting
+
+`--force` - Normally, the script creates the transaction and then requires the user to manually verify and enter a string to signal consent, before submitting the transaction to the network. When this flag is used, it skips this step and automatically submits it. Use only when you know what you are doing.
+
+`--noblock` - Without this flag, the script waits until the transaction is included in the next block. If you have a lot of addresses and use a script to process them, this can take a long time. When this flag is set, the script will finish after the transaction is included in the target network mempool. It's useful in combination with the `--force` parameter, because it allows mass processing of many addresses in an automated way.
+ 
 ---
 
 There is another python script for claiming FBTC (Fast Bitcoin). The FBTC network is based on the BitShares codebase, so it does not support Segwit. There are no TXIDs or change addresses,
 and you can transfer arbitrary amounts from an address multiple times.
 
 Usage:
-    
+
     fbtcclaimer.py <private key in WIF format> <public source address> <destination address> <number of satoshis to send, including fee>
     fbtcclaimer.py 5K2YUVmWfxbmvsNxCsfvArXdGXm7d5DC9pn4yD75k2UaSYgkXTh 1HKqKTMpBTZZ8H5zcqYEWYBaaWELrDEXeE 1aa5cmqmvQq8YQTEqcTmW7dfBNuFwgdCD 3053
-    
+
 fbtcclaimer.py also requires aes.py to be in the same folder as the script. Thanks to https://github.com/ricmoo/pyaes for the implementation.
 
 ---

--- a/claimer.py
+++ b/claimer.py
@@ -30,83 +30,83 @@ def bech32decode(addr):
     assert bech32_polymod(bech32_hrp_expand(hrp) + data) == 1, "bech32 checksum failed"
     assert data[0] == 0, "only support version 0 witness for now"
     data = data[1:-6]
-    
+
     n = 0
     for c in data:
         n = n << 5 | c
 
     nbytes, extrabits = divmod(len(data) * 5, 8)
     return long2byte(n >> extrabits, nbytes)
-  
+
 def bech32encode(hrp, s):
     extrabits = (5 - ((len(s) * 8) % 5)) % 5
     nchars = (len(s) * 8 + extrabits) / 5
     n = byte2long(s) << extrabits
-    
+
     data = []
     for i in xrange(nchars):
         data.insert(0, n & 31)
         n >>= 5
-        
+
     data.insert(0, 0) # version 0
-    
+
     values = bech32_hrp_expand(hrp) + data
     polymod = bech32_polymod(values + [0,0,0,0,0,0]) ^ 1
     data += [(polymod >> 5 * (5 - i)) & 31 for i in range(6)]
     return hrp + "1" + "".join(bech32ab[c] for c in data)
-  
+
 def b58csum(s):
     return hashlib.sha256(hashlib.sha256(s).digest()).digest()[0:4]
-    
+
 def b58decode(s, checksum=True):
     idx = 0
     while s[idx] == "1":
         idx += 1
-        
+
     n = 0
     for c in s[idx:]:
         n = n * 58 + b58ab.index(c)
-        
+
     res = long2byte(n)
     res = idx * "\x00" + res
-    
+
     if checksum:
         res, cs = res[:-4], res[-4:]
         assert cs == b58csum(res), "base58 checksum failed"
-        
+
     return res
 
 def b58encode(s, checksum=True):
     if checksum:
         s += b58csum(s)
-        
+
     idx = 0
     while s[idx] == "\x00":
         idx += 1
-        
+
     n = byte2long(s)
     res = ""
     while n > 0:
         res = b58ab[n % 58] + res
         n /= 58
-        
+
     return "1" * idx + res
-    
+
 def byte2long(s):
     res = 0
     for c in s:
         res = (res << 8) | ord(c)
     return res
-    
+
 def long2byte(n, sz=None):
     res = ""
     while n > 0:
         res = chr(n & 0xff) + res
         n >>= 8
-        
+
     if sz is not None:
         res = res.rjust(sz, "\x00")
-        
+
     return res
 
 def read_varint(st):
@@ -119,7 +119,7 @@ def read_varint(st):
         return struct.unpack("<L", st.read(4))[0]
     if value == 0xff:
         return struct.unpack("<Q", st.read(8))[0]
-        
+
 def make_varint(value):
     if value < 0xfd:
         return chr(value)
@@ -127,12 +127,12 @@ def make_varint(value):
         return "\xfd" + struct.pack("<H", value)
     if value <= 0xffffffff:
         return "\xfe" + struct.pack("<L", value)
-    
+
     return "\xff" + struct.pack("<Q", value)
 
 def lengthprefixed(s):
     return make_varint(len(s)) + s
-    
+
 def modinv(x, n):
     return pow(x, n-2, n)
 
@@ -141,14 +141,14 @@ class Point(object):
         self.x = x
         self.y = y
         self.inf = inf
-        
+
 def curve_add(p, q, N):
     if p.inf:
         return q
-        
+
     if q.inf:
         return p
-    
+
     if p.x == q.x:
         if p.y == q.y:
             d1 = (3 * p.x * p.x) % N
@@ -161,12 +161,12 @@ def curve_add(p, q, N):
 
     d2i = modinv(d2, N)
     d = (d1 * d2i) % N
-        
+
     resx = (d * d - p.x - q.x) % N
     resy = (d * (p.x - resx) - p.y) % N
-    
+
     return Point(resx, resy)
-    
+
 def scalar_mul(scalar, p, N):
     t = p
     res = None
@@ -176,25 +176,25 @@ def scalar_mul(scalar, p, N):
                 res = t
             else:
                 res = curve_add(res, t, N)
-        
+
         t = curve_add(t, t, N)
-        
+
         scalar = scalar >> 1
-        
+
     return res
 
 def der_signature(r, s):
     r = long2byte(r)
     if ord(r[0]) >= 0x80:
         r = "\x00" + r
-        
+
     s = long2byte(s)
     if ord(s[0]) >= 0x80:
         s = "\x00" + s
-    
+
     res = "\x02" + lengthprefixed(r) + "\x02" + lengthprefixed(s)
     return "\x30" + lengthprefixed(res)
-    
+
 def gen_k_rfc6979(privkey, m):
     h1 = hashlib.sha256(m).digest()
     x = long2byte(privkey, 32)
@@ -204,37 +204,37 @@ def gen_k_rfc6979(privkey, m):
     V = hmac.new(K, V, hashlib.sha256).digest()
     K = hmac.new(K, V + "\x01" + x + h1, hashlib.sha256).digest()
     V = hmac.new(K, V, hashlib.sha256).digest()
-    
+
     while True:
         V = hmac.new(K, V, hashlib.sha256).digest()
         k = byte2long(V)
         if k >= 1 and k < R:
             return k
-        
+
         K = hmac.new(K, V + "\x00", hashlib.sha256).digest()
         V = hmac.new(K, V, hashlib.sha256).digest()
-    
+
 def signdata(privkey, data):
     h = doublesha(data)
     r, s = sign(privkey, h)
     return der_signature(r, s)
-    
+
 def sign(privkey, h):
     z = byte2long(h)
     k = gen_k_rfc6979(privkey, h)
-    
+
     p = scalar_mul(k, Point(gx, gy), N)
     r = p.x % R
     assert r != 0
-    
+
     ki = modinv(k, R)
     s = (ki * (z + r * privkey)) % R
     assert s != 0
     if s > (R / 2):
         s = R - s
-    
+
     return r, s
-    
+
 def serializepubkey(p, compressed):
     if compressed:
         if p.y & 1 == 1:
@@ -257,42 +257,42 @@ def hash160(s):
 def pubkey2h160(p, compressed):
     s = serializepubkey(p, compressed)
     return hash160(s)
-    
+
 def pubkey2segwith160(p):
     s = pubkey2h160(p, 1)
     return hash160("\x00\x14" + s)
-    
+
 def pubkey2addr(p, compressed):
     s = pubkey2h160(p, compressed)
     return b58encode("\x00" + s)
-    
+
 def pubkey2segwitaddr(p):
     s = pubkey2segwith160(p)
     return b58encode("\x05" + s)
-    
+
 def wif2privkey(s):
     s = b58decode(s)
     keytype = ord(s[0])
-    
+
     if len(s) == 34 and s[-1] == "\x01":
         compressed = 1
     elif len(s) == 33:
         compressed = 0
     else:
         raise Exception("Unknown private key WIF format!")
-        
+
     return keytype, byte2long(s[1:33]), compressed
-    
+
 def identify_keytype(wifkey, addr):
     if addr.startswith("bc1"):
         addrh160 = bech32decode(addr)
         assert len(addrh160) == 20
-        
+
         privkeytype, privkey, compressed = wif2privkey(args.wifkey)
         pubkey = scalar_mul(privkey, Point(gx, gy), N)
         if addrh160 == pubkey2h160(pubkey, 1):
             return "segwitbech32", privkey, pubkey, addrh160, 1
-        
+
         raise Exception("Unable to identify key type!")
     else:
         addrh160 = b58decode(addr)[1:]
@@ -302,13 +302,13 @@ def identify_keytype(wifkey, addr):
         pubkey = scalar_mul(privkey, Point(gx, gy), N)
         if addrh160 == pubkey2h160(pubkey, 0):
             return "standard", privkey, pubkey, addrh160, 0
-            
+
         if addrh160 == pubkey2h160(pubkey, 1):
             return "standard", privkey, pubkey, addrh160, 1
-            
+
         if addrh160 == pubkey2segwith160(pubkey):
             return "segwit", privkey, pubkey, pubkey2h160(pubkey, 1), 1
-            
+
         raise Exception("Unable to identify key type!")
 
 def get_tx_details_from_blockchaininfo(txid, addr, hardforkheight):
@@ -321,7 +321,7 @@ def get_tx_details_from_blockchaininfo(txid, addr, hardforkheight):
         print "You will most likely be unable to claim these coins."
         print "Please look for an earlier transaction before the fork point.\n\n"
         get_consent("I will try anyway")
-        
+
     found = None
     for outinfo in txinfo["out"]:
         if outinfo["addr"] == addr:
@@ -333,32 +333,32 @@ def get_tx_details_from_blockchaininfo(txid, addr, hardforkheight):
                 found = txindex, script, satoshis
             else:
                 raise Exception("Multiple outputs with that address found! Aborting!")
-                
+
     if not found:
         raise Exception("No output with address %s found in transaction %s" % (addr, txid))
-        
+
     return found
-    
+
 def get_btx_details_from_chainz_cryptoid(addr):
     print "Querying chainz.cryptoid.info about last unspent transaction for address"
     url = "https://chainz.cryptoid.info/btx/api.dws?q=unspent&active=%s&key=a660e3112b78" % addr
 
     request = urllib2.Request(url)
     request.add_header('User-Agent', 'Mozilla/5.0')
-    opener = urllib2.build_opener() 
+    opener = urllib2.build_opener()
     res = opener.open(request)
-    
+
     txinfo = json.loads(res.read())
     unspent_outputs = txinfo["unspent_outputs"]
     if len(unspent_outputs) == 0:
         raise Exception("Block explorer didn't find any coins at that address")
-    
+
     outinfo = unspent_outputs[0]
     txid = outinfo["tx_hash"]
     txindex = outinfo["tx_ouput_n"]
     script = outinfo["script"].decode("hex")
     satoshis = int(outinfo["value"])
-    
+
     return txid, txindex, script, satoshis
 
 def get_consent(consentstring):
@@ -369,23 +369,23 @@ def get_consent(consentstring):
         raise Exception("User did not write '%s', aborting" % consentstring)
 
 class Client(object):
-    
+
     _MAX_MEMPOOL_CHECKS = 5
     _MAX_CONNECTION_RETRIES = 100
-    
+
     def __init__(self, coin):
         self.coin = coin
         self._transaction_sent = False
         self._transaction_accepted = None
         self._mempool_check_count = 0
         self._connection_retries = 0
-        
+
     def send(self, cmd, msg):
         magic = struct.pack("<L", self.coin.magic)
         wrapper = magic + cmd.ljust(12, "\x00") + struct.pack("<L", len(msg)) + hashlib.sha256(hashlib.sha256(msg).digest()).digest()[0:4] + msg
         self.sc.sendall(wrapper)
         print "---> %s (%d bytes)" % (repr(cmd), len(msg))
-        
+
     def recv_msg(self):
         def recv_all(length):
             ret = ""
@@ -404,7 +404,7 @@ class Client(object):
         payloadlen = struct.unpack("<I", header[16:20])[0]
         payload = recv_all(payloadlen)
         return cmd, payload
-        
+
     def send_tx(self, txhash, tx, checkfee):
         serverindex = ord(os.urandom(1)) % len(self.coin.seeds)
         txhash_hexfmt = txhash[::-1].encode("hex")
@@ -415,7 +415,7 @@ class Client(object):
                 self.sc = socket.create_connection(address, 10)
                 print "SUCCESS!"
                 self.sc.settimeout(120)
-                
+
                 services = 0
                 localaddr = "\x00" * 8 + "00000000000000000000FFFF".decode("hex") + "\x00" * 6
                 nonce = os.urandom(8)
@@ -429,11 +429,11 @@ class Client(object):
                     print "<--- '%s' (%d bytes)" % (cmd, len(payload))
                     if cmd == "version":
                         client.send("verack", "")
-                        
+
                     elif cmd == "sendheaders":
                         msg = make_varint(0)
                         client.send("headers", msg)
-                        
+
                     elif cmd == "ping":
                         client.send("pong", payload)
 
@@ -444,7 +444,7 @@ class Client(object):
                             print "\tRe-sent transaction: %s" % txhash_hexfmt
 
                         client.send("mempool", "")
-                        
+
                     elif cmd == "getdata":
                         if payload == "\x01\x01\x00\x00\x00" + txhash:
                             print "\tPeer requesting transaction details for %s" % txhash_hexfmt
@@ -456,7 +456,7 @@ class Client(object):
                         elif self._transaction_sent:
                             print "\tReceived getdata without our txhash. The transaction may have been rejected."
                             print "\tThis script will retransmit the transaction and monitor the mempool for a few minutes before giving up."
-                         
+
                     elif cmd == "feefilter":
                         minfee = struct.unpack("<Q", payload)[0]
                         print "\tserver requires minimum fee of %d satoshis" % minfee
@@ -464,7 +464,7 @@ class Client(object):
                             print "\tour fee is >= minimum fee, so should be OK"
                         else:
                             print "\tOUR FEE IS TOO SMALL, transaction might not be accepted"
-                            
+
                     elif cmd == "inv":
                         blocks_to_get = []
                         st = cStringIO.StringIO(payload)
@@ -481,16 +481,21 @@ class Client(object):
                             elif i == 10:
                                 print "\t..."
                                 print "\tNot printing additional %d transactions" % (ninv - i)
-                            
+
                             if invtype == 1:
                                 if invhash == txhash:
                                     transaction_found = True
                             elif invtype == 2:
                                 blocks_to_get.append(invhash)
-                        if transaction_found and not self._transaction_accepted:        
+                        if transaction_found and not self._transaction_accepted:
                             print "\n\tOUR TRANSACTION IS IN THEIR MEMPOOL, TRANSACTION ACCEPTED! YAY!"
-                            print "\tConsider leaving this script running until it detects the transaction in a block."
                             self._transaction_accepted = True
+                            if args.noblock:
+                                # User specified --noblock, we are done here
+                                return
+                            else:
+                                print "\tConsider leaving this script running until it detects the transaction in a block."
+
                         elif transaction_found:
                             print "\tTransaction still in mempool. Continue waiting for block inclusion."
                         elif not blocks_to_get:
@@ -506,7 +511,7 @@ class Client(object):
                             msg = make_varint(len(inv)) + "".join(inv)
                             client.send("getdata", msg)
                             print "\trequesting %d blocks" % len(blocks_to_get)
-                        
+
                     elif cmd == "block":
                         if tx in payload or plaintx in payload:
                             print "\tBLOCK WITH OUR TRANSACTION OBSERVED! YES!"
@@ -514,7 +519,7 @@ class Client(object):
                             return
                         else:
                             print "\tTransaction not included in observed block."
-                            
+
                     elif cmd == "addr":
                         st = cStringIO.StringIO(payload)
                         naddr = read_varint(st)
@@ -527,7 +532,7 @@ class Client(object):
                             print "\tGot peer address: %s" % address
                     elif cmd not in ('sendcmpct', 'verack'):
                         print repr(cmd), repr(payload)
-                
+
             except (socket.error, socket.herror, socket.gaierror, socket.timeout) as e:
                 if self._connection_retries >= self._MAX_CONNECTION_RETRIES:
                     raise
@@ -537,7 +542,7 @@ class Client(object):
                 self._connection_retries += 1
                 time.sleep(2)
 
-    
+
 class BitcoinFork(object):
     def __init__(self):
         self.coinratio = 1.0
@@ -551,26 +556,26 @@ class BitcoinFork(object):
         self.PUBKEY_ADDRESS = chr(0)
         self.SCRIPT_ADDRESS = chr(5)
         self.bch_fork = False
-        
+
     def maketx_segwitsig(self, sourcetx, sourceidx, sourceh160, signscript, sourcesatoshis, sourceprivkey, pubkey, compressed, outputs, fee, keytype):
         verifytotal = fee
-        
+
         version = struct.pack("<I", self.txversion)
         prevout = sourcetx.decode("hex")[::-1] + struct.pack("<I", sourceidx)
         sequence = struct.pack("<i", -1)
         inscript = lengthprefixed(signscript)
         satoshis = struct.pack("<Q", sourcesatoshis)
-        
+
         txouts = ""
         for outscript, amount, destaddr, rawaddr in outputs:
             txouts += struct.pack("<Q", amount) + lengthprefixed(outscript)
             verifytotal += amount
-        
+
         locktime = struct.pack("<I", 0)
         sigtype = struct.pack("<I", self.signid)
-        
+
         to_sign = version + self.BCDgarbage + doublesha(prevout) + doublesha(sequence) + prevout + inscript + satoshis + sequence + doublesha(txouts) + locktime + sigtype + self.extrabytes
-        
+
         signature = signdata(sourceprivkey, to_sign) + make_varint(self.signtype)
         serpubkey = serializepubkey(pubkey, compressed)
 
@@ -587,54 +592,54 @@ class BitcoinFork(object):
             script = "\x00"
         else:
             raise Exception("Not implemented!")
-            
+
         plaintx = version + self.BCDgarbage + make_varint(1) + prevout + script + sequence + make_varint(len(outputs)) + txouts + locktime
-        
+
         if verifytotal != sourcesatoshis:
             raise Exception("Addition of output amounts does not match input amount (Bug?), aborting")
-            
+
         if keytype in ("p2pk", "standard"):
             return plaintx, plaintx
         else:
             witnesstx = version + self.BCDgarbage + "\x00\x01" + plaintx[4+len(self.BCDgarbage):-4] + "\x02" + sigblock + locktime
             return witnesstx, plaintx
-        
+
     def maketx_basicsig(self, sourcetx, sourceidx, sourceh160, signscript, sourcesatoshis, sourceprivkey, pubkey, compressed, outputs, fee, keytype):
         if keytype in ("segwit", "segwitbech32"):
             return self.maketx_segwitsig(sourcetx, sourceidx, sourceh160, signscript, sourcesatoshis, sourceprivkey, pubkey, compressed, outputs, fee, keytype)
-            
+
         verifytotal = fee
-        
+
         version = struct.pack("<I", self.txversion)
         prevout = sourcetx.decode("hex")[::-1] + struct.pack("<I", sourceidx)
         sequence = struct.pack("<i", -1)
         inscript = lengthprefixed(signscript)
-        
+
         txouts = ""
         for outscript, amount, destaddr, rawaddr in outputs:
             txouts += struct.pack("<Q", amount) + lengthprefixed(outscript)
             verifytotal += amount
-        
+
         locktime = struct.pack("<I", 0)
         sigtype = struct.pack("<I", self.signid)
-        
+
         to_sign = version + self.BCDgarbage + make_varint(1) + prevout + inscript + sequence + make_varint(len(outputs)) + txouts + locktime + sigtype + self.extrabytes
-        
+
         signature = signdata(sourceprivkey, to_sign) + make_varint(self.signtype)
         serpubkey = serializepubkey(pubkey, compressed)
-        
+
         if keytype == "p2pk":
             sigblock = lengthprefixed(signature)
         else:
             sigblock = lengthprefixed(signature) + lengthprefixed(serpubkey)
-        
+
         plaintx = version + self.BCDgarbage + make_varint(1) + prevout + lengthprefixed(sigblock) + sequence + make_varint(len(outputs)) + txouts + locktime
-        
+
         if verifytotal != sourcesatoshis:
             raise Exception("Addition of output amounts does not match input amount (Bug?), aborting")
-            
+
         return plaintx, plaintx
-        
+
 class BitcoinFaith(BitcoinFork):
     def __init__(self):
         BitcoinFork.__init__(self)
@@ -734,7 +739,7 @@ class SuperBitcoin(BitcoinFork):
         self.signid = self.signtype
         self.maketx = self.maketx_basicsig # does not use new-style segwit signing for standard transactions
         self.extrabytes = lengthprefixed("sbtc")
-        
+
 class BitcoinDiamond(BitcoinFork):
     def __init__(self):
         BitcoinFork.__init__(self)
@@ -750,7 +755,7 @@ class BitcoinDiamond(BitcoinFork):
         self.txversion = 12
         self.BCDgarbage = "\xff" * 32
         self.coinratio = 10.0
-        
+
 class BitcoinPizza(BitcoinFork):
     def __init__(self):
         BitcoinFork.__init__(self)
@@ -835,7 +840,7 @@ class BitCore(BitcoinFork):
         self.signtype = 0x01
         self.signid = self.signtype
         self.maketx = self.maketx_basicsig # does not use new-style segwit signing for standard transactions
-        
+
 class BitcoinPay(BitcoinFork):
     def __init__(self):
         BitcoinFork.__init__(self)
@@ -860,7 +865,7 @@ class BitcoinKing(BitcoinFork):
         self.seeds = ("47.52.28.49",)
         self.signtype = 0x41
         self.signid = self.signtype | (143 << 8)
-        
+
 # https://github.com/bitcoincandyofficial/bitcoincandy
 class BitcoinCandy(BitcoinFork):
     def __init__(self):
@@ -909,7 +914,7 @@ class WorldBitcoin(BitcoinFork):
         self.extrabytes = lengthprefixed("wbtc")
         self.maketx = self.maketx_basicsig
         self.coinratio = 100.0
-        
+
 # https://github.com/Bitcoin-ABC/bitcoin-abc
 class BitcoinCash(BitcoinFork):
     def __init__(self):
@@ -938,6 +943,8 @@ parser.add_argument("--txindex", help="Manually specified txindex, skips blockch
 parser.add_argument("--satoshis", help="Manually specified number of satoshis, skips blockchain.info API query", type=int)
 parser.add_argument("--p2pk", help="Source is P2PK. Use this if you have REALLY old coins (2009-2010) and normal mode fails", action="store_true")
 parser.add_argument("--height", help="Manually specified block height of transaction, optional", type=int)
+parser.add_argument("--force", help="Do not require consent, submit transaction directly", action="store_true")
+parser.add_argument("--noblock", help="Do not wait for block confirmation, finish after the transaction is in mempool", action="store_true")
 
 args = parser.parse_args()
 
@@ -981,7 +988,7 @@ elif args.cointicker == "UBTC":
     coin = UnitedBitcoin()
 elif args.cointicker == "WBTC":
     coin = WorldBitcoin()
-    
+
 if args.height and coin.hardforkheight < args.height:
     print "\n\nTHIS TRANSACTION HAPPENED AFTER THE COIN FORKED FROM THE MAIN CHAIN, exiting"
     print "(fork at height %d)" % coin.hardforkheight
@@ -1018,7 +1025,7 @@ else:
         raise Exception("Block explorer for BCH forks not supported yet. Please specify txindex and satoshis manually.")
     else:
         txindex, bciscript, satoshis = get_tx_details_from_blockchaininfo(args.txid, args.srcaddr, coin.hardforkheight)
-    
+
     if bciscript != srcscript:
         raise Exception("Script type in source output that is not supported!")
 
@@ -1032,7 +1039,7 @@ for output in args.destaddr.split(","):
         amount = int(amount)
         if amount > remaining:
             raise Exception("Specified satoshis amount exceeds remaining balance")
-        
+
     if destaddr.startswith("bc1"):
         rawaddr = bech32decode(destaddr)
         assert len(rawaddr) == 20
@@ -1063,7 +1070,7 @@ for i in xrange(len(outputs)):
             remaining = 0
         else:
             raise Exception("Two outputs without specified amounts, can't continue")
-    
+
 if remaining != 0:
     raise Exception("Addition of output amounts does not match input amount (Bug?), aborting")
 
@@ -1072,7 +1079,7 @@ if keytype in ("p2pk", "standard", "segwit", "segwitbech32"):
     txhash = doublesha(plaintx)
 else:
     raise Exception("Not implemented!")
-    
+
 print "Raw transaction"
 print tx.encode("hex")
 print
@@ -1085,7 +1092,7 @@ for outscript, amount, destaddr, rawaddr in outputs:
     coinamount = amount * coin.coinratio / 100000000.0
     btcamount = amount / 100000000.0
     print "    %.8f %s (equivalent to %.8f BTC) TO %s" % (coinamount, coin.ticker, btcamount, destaddr)
-    
+
 coinamount = args.fee * coin.coinratio / 100000000.0
 btcamount = args.fee / 100000000.0
 print "!!! %.8f %s (equivalent to %.8f BTC) WILL BE SENT AS FEES! CONTINUE AT YOUR OWN RISK !!!" % (coinamount, coin.ticker, btcamount)
@@ -1104,11 +1111,12 @@ for outscript, amount, destaddr, rawaddr in outputs:
         idx = tx.index(rawaddr[11:21])
         part1 = tx[idx-10:idx]
         testaddr = b58encode(rawaddr[0] + part1 + part2)
-        
+
     if destaddr != testaddr or outscript not in tx:
         raise Exception("Corrupted destination address! Check your RAM!")
 
-get_consent("I am sending coins on the %s network and I accept the risks" % coin.fullname)
+if not args.force:
+    get_consent("I am sending coins on the %s network and I accept the risks" % coin.fullname)
 
 print "generated transaction", txhash[::-1].encode("hex")
 print "\n\nConnecting to servers and pushing transaction\nPlease wait for a minute before stopping the script to see if it entered the server mempool.\n\n"
@@ -1124,8 +1132,7 @@ if coin.ticker == "BTP":
     else:
         print "Server says transaction push failed!", repr(res)
         print "Transaction might still have been accepted, wait for a few minutes to see if it arrives."
-    
+
 else:
     client = Client(coin)
     client.send_tx(txhash, tx, args.fee)
-

--- a/claimer.py
+++ b/claimer.py
@@ -701,11 +701,10 @@ class Bitcoin2X(BitcoinFork):
         self.hardforkheight = 501451
         self.magic = 0xd8b5b2f4
         self.port = 8333
-        self.seeds = ("node1.b2x-segwit.io", "node2.b2x-segwit.io", "node3.b2x-segwit.io", "136.243.147.159", "136.243.171.156", "46.229.165.141", "178.32.3.12")
-        self.signtype = 0x21
-        self.signid = self.signtype
+        self.seeds = ("node1.b2x-segwit.io", "node2.b2x-segwit.io", "node3.b2x-segwit.io")
+        self.signtype = 0x31
+        self.signid = self.signtype << 1
         self.maketx = self.maketx_basicsig # does not use new-style segwit signing for standard transactions
-        self.versionno = 70015 | (1 << 27)
 
 class UnitedBitcoin(BitcoinFork):
     def __init__(self):


### PR DESCRIPTION
I added two new parameters (--force and --noblock) for usage with scripting. It helps if you have many addresses to process. My editor removed the unnecessary whitespace at empty lines when saving. I left it like that to clean up the source code. If you want me to put it back in to make the diff more readable let me know.